### PR TITLE
Minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PIP := .env/bin/pip
 PYTHON := .env/bin/python
 TOX := .env/bin/tox
 STAGE := DEV
-HUMILIS_ENV := tests/integration/humilis-sam
+HUMILIS_ENV := tests/integration/humilis-sam-swagger tests/integration/humilis-sam-classic
 
 # create virtual environment
 .env:
@@ -28,21 +28,27 @@ configure:
 
 # deploy the test environment
 create: develop
-	$(HUMILIS) create \
-		--stage $(STAGE) \
-		--output $(HUMILIS_ENV)-$(STAGE).outputs.yaml \
-		$(HUMILIS_ENV).yaml
+	for env in $(HUMILIS_ENV) ; do \
+		$(HUMILIS) create \
+			--stage $(STAGE) \
+			--output $$env-$(STAGE).outputs.yaml \
+			$$env.yaml ; \
+	done
 
 # update the test deployment
 update: develop
-	$(HUMILIS) update \
-		--stage $(STAGE) \
-		--output $(HUMILIS_ENV)-$(STAGE).outputs.yaml \
-		$(HUMILIS_ENV).yaml
+	for env in $(HUMILIS_ENV) ; do \
+		$(HUMILIS) update \
+			--stage $(STAGE) \
+			--output $$env-$(STAGE).outputs.yaml \
+			$$env.yaml ; \
+	done
 
 # delete the test deployment
 delete: develop
-	$(HUMILIS) delete --stage $(STAGE) $(HUMILIS_ENV).yaml
+	for env in $(HUMILIS_ENV) ; do \
+		$(HUMILIS) delete --stage $(STAGE) $$env.yaml ; \
+	done
 
 # upload to Pypi
 pypi: develop

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ automatically and outputed next to your environment file.
 
 See [humilis][humilis] documentation.
 
-[humilis]: https://github.com//humilis/blob/master/README.md
+[humilis]: https://github.com/humilis/humilis/blob/master/README.md
 
 
 ## Contact
@@ -95,7 +95,7 @@ This software is licensed under the [MIT license][mit].
 
 See [License file][LICENSE].
 
-[LICENSE]: https://github.com/humilis/humilis-elasticache/blob/master/LICENSE.txt
+[LICENSE]: https://github.com/humilis/humilis-sam/blob/master/LICENSE.txt
 
 
 © 2017 Arnaud Charpentier, [Find Hotel][fh] and others.

--- a/humilis_sam/__init__.py
+++ b/humilis_sam/__init__.py
@@ -1,5 +1,5 @@
 """Humilis plug-in to deploy a SAM application."""
 
 
-__version__ = "0.0.8"
+__version__ = "0.0.9"
 __author__ = "Arnaud Charpentier, FindHotel BV"

--- a/humilis_sam/meta.yaml.j2
+++ b/humilis_sam/meta.yaml.j2
@@ -1,7 +1,7 @@
 ---
 meta:
     description:
-        Deploy a SAM application
+        {{description|default('Deploy a SAM application')}}
 
     parameters:
         {% if swagger %}
@@ -32,6 +32,7 @@ meta:
               {% for path in swagger.paths %}
                 {% for f in path.functions %}
                 - name: {{f.name}}
+                  description: {{f.description or ""}}
                   api_path: {{f.api_path}}
                   http_method: {{f.http_method}}
                   fct: {{f.handler}}
@@ -103,7 +104,7 @@ meta:
             description:
                 description field of the deployed lambda functions
             value:
-                Function part of a SAM app deployed by {{_env.name}}-{{_env.stage}}
+                Part of a SAM app deployed by {{_env.name}}-{{_env.stage}}
 
         runtime:
             description:

--- a/humilis_sam/outputs.yaml.j2
+++ b/humilis_sam/outputs.yaml.j2
@@ -1,5 +1,19 @@
 ---
 outputs:
+    {% if swagger_template %}
+    RestApiId:
+        Description:
+            Api Gateway API ID
+        Value:
+            Ref: ApiGateway
+
+    ApiKey:
+        Description:
+            Name of the API Key associated to stage {{_env.stage}}
+        Value:
+            Ref: ApiKey
+    {% endif %}
+
     {% for f in meta_functions %}
     {{f.name}}LambdaFunctionArn:
         Description: The ARN of the {{f.name}} lambda function
@@ -17,7 +31,7 @@ outputs:
                 - - 'https://'
                   - Ref:
                       {% if swagger_template %}
-                      ApiGateway{{_layer.name}}{{_env.stage}}
+                      ApiGateway
                       {% else %}
                       ServerlessRestApi
                       {% endif %}

--- a/humilis_sam/resources.yaml.j2
+++ b/humilis_sam/resources.yaml.j2
@@ -1,11 +1,20 @@
 ---
 resources:
     {% if swagger_template %}
-    ApiGateway{{_layer.name}}{{_env.stage}}:
+    ApiKey:
+      Type: "AWS::ApiGateway::ApiKey"
+      DependsOn:
+        - ApiGateway
+      Properties:
+        Name: "{{_env.name}}-{{_env.stage|lower}}"
+        Description: "API key for stage {{_env.stage}} of environment {{_env.name}}"
+        Enabled: "true"
+
+    ApiGateway:
         Type: AWS::Serverless::Api
         Properties:
             DefinitionUri: {{swagger_template}}
-            StageName: {{_env.stage}}
+            StageName: {{_env.stage|lower}}
             {% if cache %}
             CacheClusterEnabled: True
             CacheClusterSize: "{{cache}}"
@@ -16,6 +25,7 @@ resources:
                 {% endfor %}
     {% endif %}
 
+    {% set default_description="SAM app" %}
     {% for f in meta_functions %}
     {{f.name}}:
         Type: AWS::Serverless::Function
@@ -23,13 +33,13 @@ resources:
             Handler: handler.lambda_handler
             Runtime: {{runtime}}
             CodeUri: {{lambda_function}}
-            Description: {{func_description}}
+            Description: "{{f.description or default_description}} ({{_env.name}}-{{_env.stage}})"
             MemorySize: {{f.memory_size}}
             Timeout: {{f.timeout}}
             {% if iam_actions %}
             Role:
                 "Fn::GetAtt":
-                    - LambdaRole{{_layer.name}}{{_env.stage}}
+                    - LambdaRole
                     - Arn
             {% endif %}
             {% if env_vars %}
@@ -55,7 +65,7 @@ resources:
                     Type: Api
                     Properties:
                         {% if swagger_template %}
-                        RestApiId: {"Ref": "ApiGateway{{_layer.name}}{{_env.stage}}"}
+                        RestApiId: {"Ref": "ApiGateway"}
                         {% endif %}
                         Path: {{f.api_path}}
                         Method: {{f.http_method}}
@@ -80,7 +90,7 @@ resources:
     {% endif %}
 
     {% if iam_actions %}
-    LambdaRole{{_layer.name}}{{_env.stage}}:
+    LambdaRole:
         Type: "AWS::IAM::Role"
         Properties:
             AssumeRolePolicyDocument:

--- a/humilis_sam/swagger.yaml.j2
+++ b/humilis_sam/swagger.yaml.j2
@@ -54,6 +54,7 @@ paths:
     {{path.functions[0].api_path}}:
         {% for f in path.functions %}
         {{f.http_method}}:
+            description: {{f.description or ""}}
             response: {}
             {% if security %}
             security:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -23,7 +23,7 @@ def settings(request):
 
 @pytest.yield_fixture(scope="session")
 def environment(settings):
-    """The test environment: this fixtures creates it and takes care of
+    """The test environment: this fixture creates it and takes care of
     removing it after tests have run."""
     env = Environment(settings.environment_path, stage=settings.stage)
     if settings.update == "yes":

--- a/tests/integration/humilis-sam-classic.yaml
+++ b/tests/integration/humilis-sam-classic.yaml
@@ -7,6 +7,7 @@ humilis-sam-testi-classic:
 
         - layer: dummyAPIclassic
           layer_type: sam
+          description: A dummy humilis-sam layer to test the humilis-sam plugin
           runtime: python2.7
           lambda_dependencies:
               - ./my_pckg

--- a/tests/integration/humilis-sam-swagger.yaml
+++ b/tests/integration/humilis-sam-swagger.yaml
@@ -7,6 +7,7 @@ humilis-sam-testi-swagger:
 
         - layer: dummyAPIswagger
           layer_type: sam
+          description: A dummy humilis-sam layer to test the humilis-sam plugin
           runtime: python2.7
           lambda_dependencies:
               - ./my_pckg
@@ -40,6 +41,7 @@ humilis-sam-testi-swagger:
             paths:
                 - functions:
                     - name: DummyGetResource
+                      description: "Get something"
                       handler: "my_pckg.api:get"
                       api_path: /resource
                       http_method: get
@@ -53,12 +55,14 @@ humilis-sam-testi-swagger:
                       timeout: 120
 
                     - name: DummyDeleteResource
+                      description: "Delete something"
                       handler: "my_pckg.api:delete"
                       api_path: /resource
                       http_method: delete
 
                 - functions:
                     - name: DummyGetId
+                      description: "Get something else"
                       handler: "my_pckg.api:get"
                       api_path: /id
                       http_method: get


### PR DESCRIPTION
This PR bundles a few minor fixes:

* Fix the makefile targets `create` and `delete`
* Fix README links
* Allow layer users to override the layer description
* Add explanatory layer descriptions to the test environments
* Allow method-specific descriptions in API
* Simplify logical resource names in CF template
* Create an API Key for each deployment stage