### PR TITLE
Adjust rate time to keep the lambda functions warm

### DIFF
--- a/humilis_sam/__init__.py
+++ b/humilis_sam/__init__.py
@@ -1,5 +1,5 @@
 """Humilis plug-in to deploy a SAM application."""
 
 
-__version__ = "0.0.9"
+__version__ = "0.0.10"
 __author__ = "Arnaud Charpentier, FindHotel BV"

--- a/humilis_sam/meta.yaml.j2
+++ b/humilis_sam/meta.yaml.j2
@@ -48,6 +48,7 @@ meta:
                   {% endif %}
                   {% if f.keep_warm %}
                   keep_warm: {{f.keep_warm}}
+                  warm_rate_time: {{f.warm_rate_time|default(2)}}
                   {% else %}
                   keep_warm: no
                   {% endif %}
@@ -77,6 +78,7 @@ meta:
                   {% endif %}
                   {% if f.keep_warm %}
                   keep_warm: {{f.keep_warm}}
+                  warm_rate_time: {{f.warm_rate_time|default(2)}}
                   {% else %}
                   keep_warm: no
                   {% endif %}

--- a/humilis_sam/resources.yaml.j2
+++ b/humilis_sam/resources.yaml.j2
@@ -73,7 +73,7 @@ resources:
                 KeepWarm:
                     Type: Schedule
                     Properties:
-                        Schedule: rate(2 minutes)
+                        Schedule: rate({{f.warm_rate_time}} minutes)
                         Input: '{"event_type": "keep_warm"}'
                 {% endif %}
 

--- a/humilis_sam/resources.yaml.j2
+++ b/humilis_sam/resources.yaml.j2
@@ -73,7 +73,7 @@ resources:
                 KeepWarm:
                     Type: Schedule
                     Properties:
-                        Schedule: rate(4 minutes)
+                        Schedule: rate(2 minutes)
                         Input: '{"event_type": "keep_warm"}'
                 {% endif %}
 

--- a/tests/integration/humilis-sam-classic.yaml
+++ b/tests/integration/humilis-sam-classic.yaml
@@ -24,6 +24,7 @@ humilis-sam-testi-classic:
                 handler: "my_pckg.api:get"
                 api_path: /resource
                 http_method: get
+                keep_warm: yes
                 memory_size: 256
 
               - name: DummyPut
@@ -31,6 +32,7 @@ humilis-sam-testi-classic:
                 api_path: /resource
                 http_method: put
                 keep_warm: yes
+                warm_rate_time: 3
                 timeout: 120
 
               - name: DummyDelete

--- a/tests/integration/humilis-sam-swagger.yaml
+++ b/tests/integration/humilis-sam-swagger.yaml
@@ -45,6 +45,7 @@ humilis-sam-testi-swagger:
                       handler: "my_pckg.api:get"
                       api_path: /resource
                       http_method: get
+                      keep_warm: yes
                       memory_size: 256
 
                     - name: DummyPutResource
@@ -52,6 +53,7 @@ humilis-sam-testi-swagger:
                       api_path: /resource
                       http_method: put
                       keep_warm: yes
+                      warm_rate_time: 3
                       timeout: 120
 
                     - name: DummyDeleteResource


### PR DESCRIPTION
I finally did some (manual) tests and 2 minutes seem to be a better rate time to keep a lambda function as warm as possible.
@germangh ready for review